### PR TITLE
Corrected message about Python version in ImportError on arjun.py

### DIFF
--- a/arjun.py
+++ b/arjun.py
@@ -13,7 +13,7 @@ print('''%s    _
 try:
     import concurrent.futures
 except ImportError:
-    print('%s Please use Python > 3.2 to run Arjun.' % bad)
+    print('%s Please use Python >= 3.4 to run Arjun.' % bad)
     quit()
 
 import re


### PR DESCRIPTION
According to README,

> Note: Arjun doesn't work with python < 3.4

But in *arjun.py* it is still,

> print('%s Please use Python > 3.2 to run Arjun.' % bad)

Just corrected it. :)