### PR TITLE
making dynamic default wordlist path

### DIFF
--- a/arjun.py
+++ b/arjun.py
@@ -20,6 +20,7 @@ import re
 import json
 import time
 import argparse
+from pathlib import Path
 
 import core.config
 from core.prompt import prompt
@@ -32,7 +33,7 @@ parser.add_argument('-u', help='target url', dest='url')
 parser.add_argument('-o', help='path for the output file', dest='output_file')
 parser.add_argument('-d', help='request delay', dest='delay', type=float, default=0)
 parser.add_argument('-t', help='number of threads', dest='threads', type=int, default=2)
-parser.add_argument('-f', help='wordlist path', dest='wordlist', default='./db/params.txt')
+parser.add_argument('-f', help='wordlist path', dest='wordlist', default=str(Path(__file__).parent.absolute())+'/db/params.txt')
 parser.add_argument('--urls', help='file containing target urls', dest='url_file')
 parser.add_argument('--get', help='use get method', dest='GET', action='store_true')
 parser.add_argument('--post', help='use post method', dest='POST', action='store_true')


### PR DESCRIPTION
This issue occurs when we create alias for arjun on bash / zshrc, arjun can't find db #66.

` root@parrot : cat ~/.zshrc | grep arjun
alias arjun="python3 /home/mburhan/tools/Arjun/arjun.py"
 root@parrot : arjun -u https://www.google.com/                                     
    _
   /_| _ '
  (  |/ /(//) v1.6
      _/      

[-] The specified file for parameters doesn't exist
` 

After adding some code success run:
`root@parrot:  arjun -u https://www.google.com/
    _
   /_| _ '
  (  |/ /(//) v1.6
      _/      

[~] Analysing the content of the webpage
[~] Analysing behaviour for a non-existent parameter
[!] Reflections: 1
[!] Response Code: 200
[!] Content Length: 195977
`
