### PR TITLE
Fix colors for win & mac

### DIFF
--- a/core/colors.py
+++ b/core/colors.py
@@ -5,7 +5,7 @@ machine = sys.platform # Detecting the os of current system
 if machine.lower().startswith(('os', 'win', 'darwin', 'ios')):
     colors = False # Colors shouldn't be displayed in mac & windows
 if not colors:
-    end = red = white = green = yellow = run = bad = good = info = que = ''
+    white = green = red = yellow = end = back = info = que = bad = good = run = res = ''
 else:
     white = '\033[97m'
     green = '\033[92m'


### PR DESCRIPTION
I noticed with the 2.0-beta Arjun isn't running on mac (Big Sur).

```
Traceback (most recent call last):
  File "/_redacted_/Arjun/arjun.py", line 6, in <module>
    from core.colors import green, end, info, bad, good, run, res
ImportError: cannot import name 'res' from 'core.colors' (/_redacted_/Arjun/core/colors.py)
```

This is easily fixed by just assigning the "empty" color to the missing vars too - see commit.