### PR TITLE
Add 'requirements.txt'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
When launching this tool on a new Ubuntu installation, I faced the error 
> ModuleNotFoundError: No module named 'requests'

So I added the `requirements.txt` file.