### PR TITLE
Show that project is available on Pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
   <a href="https://github.com/s0md3v/Arjun/releases">
     <img src="https://img.shields.io/github/release/s0md3v/Arjun.svg">
   </a>
+  <a href="https://pypi.python.org/pypi/arjun/">
+    <img src="https://img.shields.io/pypi/v/arjun.svg">
+  </a>
   <a href="https://github.com/s0md3v/Arjun/issues?q=is%3Aissue+is%3Aclosed">
       <img src="https://img.shields.io/github/issues-closed-raw/s0md3v/Arjun.svg">
   </a>


### PR DESCRIPTION
The github release badge does not mean it is available on PyPi. Just a way to let folks know it is pypi installable