### PR TITLE
add ampersands to query string in txt output

### DIFF
--- a/arjun/core/utils.py
+++ b/arjun/core/utils.py
@@ -139,8 +139,10 @@ def create_query_string(params):
     """
     query_string = ''
     for param in params:
-        pair = param + '=' + random_str(4)
+        pair = param + '=' + random_str(4) + '&'
         query_string += pair
+    if query_string.endswith('&'):
+	    query_string = query_string[:-1]
     return '?' + query_string
 
 


### PR DESCRIPTION
hey there, as it is now (v2.1.3) there is no ampersand('&') added to the query string in the url when I get the output to a txt file. For example:

https://domain.com/path.aspx?qs=5780Mid=8837MID=6381mid=5820qx=2739mID=8656mId=9718me=5346

I added some changes that fixes this. Ampersands are added:

https://domain.com/path.aspx?qs=5780&Mid=8837&MID=6381&mid=5820&qx=2739&mID=8656&mId=9718&me=5346

thank you, stay safe :)