### PR TITLE
Fixed the ' AttributeError: 'str' object has no attribute 'headers' #…

### DIFF
--- a/arjun/core/anomaly.py
+++ b/arjun/core/anomaly.py
@@ -57,7 +57,7 @@ def compare(response, factors, params):
     detects anomalies by comparing a HTTP response against a rule list
     returns string, list (anomaly, list of parameters that caused it)
     """
-    if response == '':
+    if response == '' or type(response) == str:
         return ('', [], '')
     these_headers = list(response.headers.keys())
     these_headers.sort()


### PR DESCRIPTION
> ```
> [*] Scanning 9/306: https://test.stg.example.com/api/customer
> [*] Probing the target for stability
> Traceback (most recent call last):
>   File "/usr/local/bin/arjun", line 11, in <module>
>     load_entry_point('arjun==2.2.2', 'console_scripts', 'arjun')()
>   File "/usr/local/lib/python3.8/dist-packages/arjun-2.2.2-py3.8.egg/arjun/__main__.py", line 213, in main
>     these_params = initialize(each, list(wordlist))
>   File "/usr/local/lib/python3.8/dist-packages/arjun-2.2.2-py3.8.egg/arjun/__main__.py", line 138, in initialize
>     reason = compare(response_3, factors, {zzuf[:-1]: zzuf[::-1][:-1]})[2]
>   File "/usr/local/lib/python3.8/dist-packages/arjun-2.2.2-py3.8.egg/arjun/core/anomaly.py", line 62, in compare
>     these_headers = list(response.headers.keys())
> AttributeError: 'str' object has no attribute 'headers'
> ```

working just fine

```
(env) ➜  Arjun git:(master) ✗ arjun -u http://127.0.0.1/vapi
    _
   /_| _ '
  (  |/ /(//) v2.2.2
      _/

[*] Probing the target for stability
[*] Analysing HTTP response for anomalies
<class 'requests.models.Response'>
[*] Analysing HTTP response for potential parameter names
[+] Heuristic scanner found 46 parameters: error, flex, deprecated, version, Hide, collapsed, Copied, down, address, email, 0, black, up, type, u, course, 1, mobileno, pin, example, url, 10px, y, in, 18px, title, n, name, center, password, otp, xml, text, description, block, m, scheme, pure, g, username, true, summary, i, expand, callbackResponses, openapi
[*] Logicforcing the URL endpoint
^C^CException ignored in: <module 'threading' from '/usr/lib/python3.11/threading.py'>
Traceback (most recent call last):
  File "/usr/lib/python3.11/threading.py", line 1560, in _shutdown
    atexit_call()
  File "/usr/lib/python3.11/concurrent/futures/thread.py", line 31, in _python_exit
    t.join()
  File "/usr/lib/python3.11/threading.py", line 1119, in join
    self._wait_for_tstate_lock()
  File "/usr/lib/python3.11/threading.py", line 1139, in _wait_for_tstate_lock
    if lock.acquire(block, timeout):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyboardInterrupt:
(env) ➜  Arjun git:(master) ✗
```

problem is in the `requester.py` file, where the `requester` function returns `str` response if it fails to make a successful HTTP request. hence the `AttributeError: 'str' object has no attribute 'headers'` error.

```python
def requester(request, payload={}):
    """
    central function for making http requests
    returns str on error otherwise response object of requests library
    """
 ```
just added a simple check for the type of variable and if it's str, simple typecast to dict as previously in the code