### PR TITLE
[REF] main: refactor the entry function to make it more readable

### DIFF
--- a/arjun/core/importer.py
+++ b/arjun/core/importer.py
@@ -95,9 +95,11 @@ def urls_import(path, method, headers, include):
 def request_import(path):
     """
     imports request from a raw request file
-    returns dict
+    returns list
     """
-    return parse_request(reader(path))
+    result = []
+    result.append(parse_request(reader(path)))
+    return result
 
 
 def importer(path, method, headers, include):
@@ -112,4 +114,4 @@ def importer(path, method, headers, include):
                 return urls_import(path, method, headers, include)
             elif line.startswith(('GET', 'POST')):
                 return request_import(path)
-            return 'unknown'
+            return []

--- a/arjun/core/utils.py
+++ b/arjun/core/utils.py
@@ -248,7 +248,7 @@ def fetch_params(host):
 def prepare_requests(args):
     """
     creates a list of request objects used by Arjun from targets given by user
-    returns list (of targs)
+    returns list (of targets)
     """
     headers = {
         'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:83.0) Gecko/20100101 Firefox/83.0',
@@ -258,6 +258,7 @@ def prepare_requests(args):
         'Connection': 'close',
         'Upgrade-Insecure-Requests': '1'
     }
+    result = []
     if type(args.headers) == str:
         headers = extract_headers(args.headers)
     elif args.headers:
@@ -266,15 +267,17 @@ def prepare_requests(args):
         headers['Content-type'] = 'application/json'
     if args.url:
         params = get_params(args.include)
-        return {
-            'url': args.url,
-            'method': mem.var['method'],
-            'headers': headers,
-            'include': params
-        }
+        result.append(
+            {
+                'url': args.url,
+                'method': mem.var['method'],
+                'headers': headers,
+                'include': params
+            }
+        ) 
     elif args.import_file:
-        return importer(args.import_file, mem.var['method'], headers, args.include)
-    return []
+        result = importer(args.import_file, mem.var['method'], headers, args.include)
+    return result
 
 
 def nullify(*args, **kwargs):


### PR DESCRIPTION
Good Day.

I am a long time user of your tool and wanted to give back by contributing to making it better, so while browsing the codebase I noticed that some functions and files requires some refactoring and modifications to increase code readability and make it more clear.

So I decided to give it a try, and decided to start with the entry point and its supporting functions.

This pull request introduces a rework of the entry main function and `prepare_request` method:

* Ensures that the prepare request returns the same datatype across all types, here it is always list.
* Modify the docstring of these supporting functions to reflect the new return datatype
* Unify the flow of code between single and multi URL parsing this reduced complexity and removed deep nesting within the body of the method.


If you welcome more contributions of this kind I'd be happy to invest more time on it, if not please feel free to close the pull request and I will respect your decision as the maintainer and creator of this tool. 
