### PR TITLE
Fix wrong attribute access

### DIFF
--- a/arjun/__main__.py
+++ b/arjun/__main__.py
@@ -132,7 +132,7 @@ def initialize(request, wordlist, single_url=False):
         response_1 = requester(request, {fuzz[:-1]: fuzz[::-1][:-1]})
         mem.var['healthy_url'] = response_1.status_code not in (400, 413, 418, 429, 503)
         if not mem.var['healthy_url']:
-            print('%s Target returned HTTP %i, this may cause problems.' % (bad, request.status_code))
+            print('%s Target returned HTTP %i, this may cause problems.' % (bad, response_1.status_code))
         if single_url:
             print('%s Analysing HTTP response for anomalies' % run)
         response_2 = requester(request, {fuzz[:-1]: fuzz[::-1][:-1]})


### PR DESCRIPTION
When response code is any of 400, 413, 418, 429, 503, mem.var['healthy_url'] is set to False, which in turn triggers the print on line 135. But there 'request.status_code' is accessed instead 'response_1.status_code'.

closes #218

![image](https://github.com/user-attachments/assets/9277ffd0-c5b0-4feb-8c46-6f320fc0f549)
