### PR TITLE
fix - bug if response_1 is a str

### DIFF
--- a/arjun/__main__.py
+++ b/arjun/__main__.py
@@ -130,6 +130,8 @@ def initialize(request, wordlist, single_url=False):
     else:
         fuzz = "z" + random_str(6)
         response_1 = requester(request, {fuzz[:-1]: fuzz[::-1][:-1]})
+        if(isinstance(response_1, str)):
+            return 'skipped'
         mem.var['healthy_url'] = response_1.status_code not in (400, 413, 418, 429, 503)
         if not mem.var['healthy_url']:
             print('%s Target returned HTTP %i, this may cause problems.' % (bad, response_1.status_code))


### PR DESCRIPTION
Hello, I was getting this bug that sometimes the requester() function returns a string with an error, in that case the initialize() function will break when accessing response_1.status_code, I fixed it by checking if the return of requester() is a string, and if it is, it will just pass

![image](https://github.com/user-attachments/assets/44ba4cde-2341-4ff0-a773-e6db35748caf)
